### PR TITLE
Add django-upgrade to pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.4
+    rev: v0.9.9
     hooks:
       - id: ruff
         args:
@@ -27,3 +27,8 @@ repos:
     hooks:
       - id: djhtml
         files: .*/templates/.*\.html$
+  - repo: https://github.com/adamchainz/django-upgrade
+    rev: 1.23.1
+    hooks:
+      - id: django-upgrade
+        args: ['--target-version', '5.0']

--- a/formula/admin.py
+++ b/formula/admin.py
@@ -281,7 +281,7 @@ class ConstructorAdmin(ModelAdmin, ImportExportModelAdmin, ExportActionModelAdmi
     )
     def custom_actions_list(self, request):
         messages.success(request, "List action has been successfully executed.")
-        return redirect(request.META["HTTP_REFERER"])
+        return redirect(request.headers["referer"])
 
     def has_custom_actions_list_permission(self, request):
         return request.user.is_superuser
@@ -302,7 +302,7 @@ class ConstructorAdmin(ModelAdmin, ImportExportModelAdmin, ExportActionModelAdmi
             request, f"Row action has been successfully executed. Object ID {object_id}"
         )
         return redirect(
-            request.META.get("HTTP_REFERER")
+            request.headers.get("referer")
             or reverse_lazy("admin:formula_constructor_changelist")
         )
 
@@ -318,7 +318,7 @@ class ConstructorAdmin(ModelAdmin, ImportExportModelAdmin, ExportActionModelAdmi
             request, f"Row action has been successfully executed. Object ID {object_id}"
         )
         return redirect(
-            request.META.get("HTTP_REFERER")
+            request.headers.get("referer")
             or reverse_lazy("admin:formula_constructor_changelist")
         )
 
@@ -328,7 +328,7 @@ class ConstructorAdmin(ModelAdmin, ImportExportModelAdmin, ExportActionModelAdmi
             request, f"Row action has been successfully executed. Object ID {object_id}"
         )
         return redirect(
-            request.META.get("HTTP_REFERER")
+            request.headers.get("referer")
             or reverse_lazy("admin:formula_constructor_changelist")
         )
 
@@ -338,7 +338,7 @@ class ConstructorAdmin(ModelAdmin, ImportExportModelAdmin, ExportActionModelAdmi
             request, f"Row action has been successfully executed. Object ID {object_id}"
         )
         return redirect(
-            request.META.get("HTTP_REFERER")
+            request.headers.get("referer")
             or reverse_lazy("admin:formula_constructor_changelist")
         )
 
@@ -352,7 +352,7 @@ class ConstructorAdmin(ModelAdmin, ImportExportModelAdmin, ExportActionModelAdmi
             request, f"Row action has been successfully executed. Object ID {object_id}"
         )
         return redirect(
-            request.META.get("HTTP_REFERER")
+            request.headers.get("referer")
             or reverse_lazy("admin:formula_constructor_changelist")
         )
 
@@ -372,7 +372,7 @@ class ConstructorAdmin(ModelAdmin, ImportExportModelAdmin, ExportActionModelAdmi
             request,
             f"Detail action has been successfully executed. Object ID {object_id}",
         )
-        return redirect(request.META["HTTP_REFERER"])
+        return redirect(request.headers["referer"])
 
     def has_custom_actions_detail_permission(self, request, object_id):
         return request.user.is_superuser

--- a/formula/middleware.py
+++ b/formula/middleware.py
@@ -24,6 +24,4 @@ class ReadonlyExceptionHandlerMiddleware:
                     "Database is operating in readonly mode. Not possible to save any data."
                 ),
             )
-            return redirect(
-                request.META.get("HTTP_REFERER", reverse_lazy("admin:login"))
-            )
+            return redirect(request.headers.get("referer", reverse_lazy("admin:login")))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ pygments = "^2.19"
 [tool.ruff]
 fix = true
 line-length = 88
-select = [
+lint.select = [
     "E",  # pycodestyle errors
     "W",  # pycodestyle warnings
     "F",  # pyflakes
@@ -34,7 +34,7 @@ select = [
     "B",  # flake8-bugbear
     "UP", # pyupgrade
 ]
-ignore = [
+lint.ignore = [
     "E501", # line too long, handled by black
     "B008", # do not perform function calls in argument defaults
     "C901", # too complex


### PR DESCRIPTION
This adds a pre-commit hook for django-upgrade and upgrades the ruff dependency to 0.9.9

Fixes: #26 