### PR TITLE
Fix DriverAdmin.display_header to always return list. Fixes: #19

### DIFF
--- a/formula/admin.py
+++ b/formula/admin.py
@@ -661,22 +661,24 @@ class DriverAdmin(GuardedModelAdmin, SimpleHistoryAdmin, ModelAdmin):
         return False
 
     @display(description=_("Driver"), header=True)
-    def display_header(self, instance: Driver):
+    def display_header(self, instance: Driver) -> list:
         standing = instance.standing_set.all().first()
 
-        if standing:
-            return [
-                instance.full_name,
-                None,
-                instance.initials,
-                {
-                    "path": static("images/avatar.jpg"),
-                    "height": 24,
-                    "width": 24,
-                    "borderless": True,
-                    # "squared": True,
-                },
-            ]
+        if not standing:
+            return []
+
+        return [
+            instance.full_name,
+            None,
+            instance.initials,
+            {
+                "path": static("images/avatar.jpg"),
+                "height": 24,
+                "width": 24,
+                "borderless": True,
+                # "squared": True,
+            },
+        ]
 
     @display(description=_("Constructor"))
     def display_constructor(self, instance: Driver):


### PR DESCRIPTION
This will always return a list on `DriverAdmin.display_header`