### PR TITLE
Fix correct arrow direction for negative values in KPI component

### DIFF
--- a/formula/templates/formula/helpers/kpi_progress.html
+++ b/formula/templates/formula/helpers/kpi_progress.html
@@ -2,8 +2,14 @@
 
 <div class="flex flex-row items-center gap-3">
     {{ total|intcomma }}
-
     <span class="flex flex-row gap-1 items-center font-normal text-sm tracking-tight {% if progress == "positive" %}text-green-700 dark:text-green-400{% elif progress == "negative" %}text-red-700 dark:text-red-400{% endif %}">
-        <span class="material-symbols-outlined">arrow_circle_up</span> <span class="font-medium">{{ percentage }}</span>
+        {% if progress == "positive" %}
+            <span class="material-symbols-outlined">arrow_circle_up</span>
+        {% elif progress == "negative" %}
+            <span class="material-symbols-outlined">arrow_circle_down</span>
+        {% else %}
+            <span class="material-symbols-outlined text-gray-500">remove_circle</span>
+        {% endif %}
+        <span class="font-medium">{{ percentage }}</span>
     </span>
 </div>


### PR DESCRIPTION
This PR fixes the arrow direction in the KPI progress component to properly reflect the trend direction. Previously, the component was showing an upward arrow for both positive and negative values, which was confusing for users.

This wrong one;
<img width="870" alt="Screenshot 2025-03-08 at 01 56 10" src="https://github.com/user-attachments/assets/62d6887c-8d29-4abe-83df-1a940878f1a9" />


I fixed it like that;
<img width="876" alt="Screenshot 2025-03-08 at 01 55 38" src="https://github.com/user-attachments/assets/37a656d8-dc4f-4bd4-ba39-6b80aaae94ed" />

