### PR TITLE
Add readonly boolean field to demonstrate styling bug

### DIFF
--- a/formula/admin.py
+++ b/formula/admin.py
@@ -694,7 +694,13 @@ class DriverAdminMixin(DjangoQLSearchMixin, ModelAdmin):
         # "picture",
         # "resume",
         "data",
+        "has_wins",
     ]
+
+    @display(description=_("Has wins"), boolean=True)
+    def has_wins(self, instance: Driver):
+        return instance.race_set.exists()
+
     list_before_template = "formula/driver_list_before.html"
     list_after_template = "formula/driver_list_after.html"
     change_form_show_cancel_button = True
@@ -873,6 +879,7 @@ class DriverAdmin(GuardedModelAdmin, SimpleHistoryAdmin, DriverAdminMixin):
             {
                 "classes": ["tab"],
                 "fields": [
+                    "has_wins",
                     "is_retired",
                     "is_active",
                     "is_hidden",


### PR DESCRIPTION
Add computed 'has_wins' field with @display(boolean=True) to DriverAdmin as a readonly field in the change form. This demonstrates the bug where readonly boolean fields use Django's default icon instead of Unfold's styled icon:

<img width="334" height="130" alt="Screenshot 2025-12-11 at 16 15 17" src="https://github.com/user-attachments/assets/c76498a5-b81b-4ced-b7a8-4ea8e7de704a" />

(`/en/admin/formula/driver/56/change/`)